### PR TITLE
docs: ASUS ProArt X870E BT USB ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ device ID and firmware patches not yet in mainline. Distributed as an
 | Foxconn/Azurewave modules | - | 14c3:6639 |
 | AMD RZ738 (MediaTek MT7927) | - | 14c3:0738 |
 | TP-Link Archer TBE550E PCIe | 0489:e116 | 14c3:7927 |
-| ASUS ProArt X870E | - | 14c3:7927 |
+| ASUS ProArt X870E | 0489:e13a | 14c3:7927 |
 | ASUS X870E-E | 13d3:3588 | 14c3:7927 |
 | Gigabyte Z790 AORUS MASTER X | 0489:e10f | 14c3:7927 |
 


### PR DESCRIPTION
I added USB Id for ASUS ProArt X870E. I have ASUS ProArt X870E Creator Wifi and `lsusb` returns:
```
Bus 001 Device 003: ID 0489:e13a Foxconn / Hon Hai Wireless_Device
```