### PR TITLE
fix: Add compat layer for older kernels

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -16,8 +16,10 @@ pkgbase = mediatek-mt7927-dkms
 	source = https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.19.6.tar.xz
 	source = extract_firmware.py
 	source = dkms.conf
+	source = apply-compat.sh
 	sha256sums = 4d9f3ff73214f68c0194ef02db9ca4b7ba713253ac1045441d4e9f352bc22e14
 	sha256sums = 5410e79d1c9170264769c7149a78bf588ec85245c1556833605fc1c4657ba37a
-	sha256sums = a663197cf356fbaf3b91c78aa683ef62608c23ab8cde922e5d22d31ecf3310ce
+	sha256sums = 056da477623fa4902db45c0d544855808264b0c166869b0b654c24f28a4bd5fb
+	sha256sums = f7c6cfe2ccc430196859ff270ab1893b490f544b26fab0038772da3ddbaca758
 
 pkgname = mediatek-mt7927-dkms

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,14 @@ $(STAMP):
 	@echo "==> Applying MT6639 Bluetooth patch..."
 	patch -d "$(SRCDIR)/bluetooth" -p3 < "$(TOPDIR)mt6639-bt-6.19.patch"
 	cp "$(TOPDIR)bluetooth.Makefile" "$(SRCDIR)/bluetooth/Makefile"
+	@echo "==> Extracting compat header: airoha_offload.h..."
+	mkdir -p "$(SRCDIR)/mt76/compat/include/linux/soc/airoha"
+	tar -xf "$(KERNEL_TARBALL)" \
+		--strip-components=2 \
+		-C "$(SRCDIR)/mt76/compat/include" \
+		"linux-$(MT76_KVER)/include/linux/soc/airoha/airoha_offload.h" \
+		2>/dev/null || \
+		echo "  (airoha_offload.h not in kernel $(MT76_KVER) tarball, skipping)"
 	@echo "==> Installing Kbuild files..."
 	cp "$(TOPDIR)mt76.Kbuild"      "$(SRCDIR)/mt76/Kbuild"
 	cp "$(TOPDIR)mt7921.Kbuild"    "$(SRCDIR)/mt76/mt7921/Kbuild"
@@ -116,6 +124,14 @@ install: sources
 	install -m644 "$(TOPDIR)mt6639-bt-6.19.patch" "$(DESTDIR)$(DKMS_PREFIX)/patches/bt/"
 	install -m644 "$(TOPDIR)mt7902-wifi-6.19.patch" "$(DESTDIR)$(DKMS_PREFIX)/patches/wifi/"
 	install -m644 $(TOPDIR)mt7927-wifi-*.patch "$(DESTDIR)$(DKMS_PREFIX)/patches/wifi/"
+	# Compat layer: apply-compat.sh + bundled headers
+	install -Dm755 "$(TOPDIR)apply-compat.sh" "$(DESTDIR)$(DKMS_PREFIX)/apply-compat.sh"
+	@if [ -d "$(SRCDIR)/mt76/compat" ]; then \
+		find "$(SRCDIR)/mt76/compat" -type f | while read f; do \
+			rel="$${f#$(SRCDIR)/mt76/}"; \
+			install -Dm644 "$$f" "$(DESTDIR)$(DKMS_PREFIX)/mt76/$$rel"; \
+		done; \
+	fi
 	@echo "==> Install complete."
 
 # ── clean ───────────────────────────────────────────────────────────

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -71,10 +71,12 @@ source=(
   "https://cdn.kernel.org/pub/linux/kernel/v${_mt76_kver%%.*}.x/linux-${_mt76_kver}.tar.xz"
   'extract_firmware.py'
   'dkms.conf'
+  'apply-compat.sh'
 )
 sha256sums=('4d9f3ff73214f68c0194ef02db9ca4b7ba713253ac1045441d4e9f352bc22e14'
             '5410e79d1c9170264769c7149a78bf588ec85245c1556833605fc1c4657ba37a'
-            'a663197cf356fbaf3b91c78aa683ef62608c23ab8cde922e5d22d31ecf3310ce')
+            '056da477623fa4902db45c0d544855808264b0c166869b0b654c24f28a4bd5fb'
+            'f7c6cfe2ccc430196859ff270ab1893b490f544b26fab0038772da3ddbaca758')
 
 # Auto-download via ASUS CDN token API
 _download_driver_zip() {

--- a/apply-compat.sh
+++ b/apply-compat.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Apply kernel compatibility fixes for building mt76 6.19 source against older kernels.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <kernel-headers-dir> <mt76-source-dir>" >&2
+    exit 1
+fi
+
+KHEADERS="$1"
+MT76_SRC="$2"
+
+if [[ ! -d "${KHEADERS}" ]]; then
+    echo "ERROR: kernel headers directory not found: ${KHEADERS}" >&2
+    exit 1
+fi
+
+if [[ ! -d "${MT76_SRC}" ]]; then
+    echo "ERROR: mt76 source directory not found: ${MT76_SRC}" >&2
+    exit 1
+fi
+
+# Fix 1: airoha_offload.h (introduced in Linux 6.19, required by mt76 wed.c)
+# Add a recursive include flag so both mt76 and mt792{1,5} subdirs
+# can find the header extracted from the kernel tarball at build time.
+AIROHA_SYS="${KHEADERS}/include/linux/soc/airoha/airoha_offload.h"
+if [[ ! -f "${AIROHA_SYS}" ]]; then
+    AIROHA_COMPAT="${MT76_SRC}/compat/include/linux/soc/airoha/airoha_offload.h"
+    KBUILD="${MT76_SRC}/Kbuild"
+    FLAG='subdir-ccflags-y += -I$(src)/compat/include'
+
+    if [[ ! -f "${AIROHA_COMPAT}" ]]; then
+        echo "ERROR: compat header not found: ${AIROHA_COMPAT}" >&2
+        exit 1
+    fi
+
+    if [[ -f "${KBUILD}" ]] && ! grep -qF "${FLAG}" "${KBUILD}"; then
+        sed -i "1i ${FLAG}" "${KBUILD}"
+        echo "compat: added recursive compat include path to mt76 Kbuild for airoha_offload.h"
+    else
+        echo "compat: recursive compat include path already in Kbuild, skipped"
+    fi
+else
+    echo "compat: airoha_offload.h already present in kernel headers, skipped"
+fi
+

--- a/dkms.conf
+++ b/dkms.conf
@@ -8,6 +8,8 @@ _BUILD="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 
 MAKE[0]="if ! grep -q 'MT6639' ${kernel_source_dir}/drivers/bluetooth/btmtk.h 2>/dev/null; then make ${_LLVM} -C ${_KDIR} M=${_BUILD}/drivers/bluetooth modules; fi && make ${_LLVM} -C ${_KDIR} M=${_BUILD}/mt76 modules"
 
+PRE_BUILD="./apply-compat.sh ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/mt76"
+
 # Bluetooth modules
 BUILT_MODULE_NAME[0]="btusb"
 BUILT_MODULE_LOCATION[0]="drivers/bluetooth"


### PR DESCRIPTION
Currently, build fails on older kernels, since non-patch related code in mt76 use features that are not present in older kernels. This PR adds patches that are confirmed to be working on 6.17 and 6.18(https://github.com/samutoljamo/bazzite-mt7927/pull/11). After, other distro-specific builds should work without workaround.

These are not "patches" in their true meaning, but I personally do not see a benefit in trying to apply real patches rather than simply using a script, since there is no need to submit these to anywhere. It is also checked does upstream already have the required changes.


Fix 1: Adding the airoha headers not present in older kernels
see: https://github.com/torvalds/linux/commit/377aa17d2aedc98d1c3bbe7e49b22a0c76308b0e#diff-051c3eac419b1b694af7a293a3a748a991ce0047c8723db6ab49efadc3764d5a
In upstream, this enables offloading some processing to an airoha NPU chip when `CONFIG_MT7996_NPU` flag is set. Airoha is not present in x86 PCs so this is safe.

In 7.0-rc2 there seems to be at least one-breaking change, but let's look at it later when arch build uses 7.0.

@vitaliemiron I saw that you have been working on enabling using the patches for Ubuntu. However, we included the distro agnostic build and after this patch, it should also compile on older kernels. Would you be able to confirm that on Ubuntu, the following works when using this fork:
```
make download
make sources
make install
sudo dkms add mediatek-mt7927/2.4
sudo dkms build mediatek-mt7927/2.4
sudo dkms install mediatek-mt7927/2.4
```