### PR TITLE
fix: Bluetooth initialization for MT7927/MT6639 (CHIPID=0x0000 and ISO interface Error 22)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(STAMP):
 		patch -d "$(SRCDIR)/mt76" -p1 < "$$p"; \
 	done
 	@echo "==> Applying MT6639 Bluetooth patch..."
-	patch -d "$(SRCDIR)/bluetooth" -p3 < "$(TOPDIR)mt6639-bt-6.19.patch"
+	@for p in $(TOPDIR)mt6639-bt-*.patch; do echo "  $$(basename "$$p")"; patch -d "$(SRCDIR)/bluetooth" -p3 < "$$p"; done
 	cp "$(TOPDIR)bluetooth.Makefile" "$(SRCDIR)/bluetooth/Makefile"
 	@echo "==> Installing Kbuild files..."
 	cp "$(TOPDIR)mt76.Kbuild"      "$(SRCDIR)/mt76/Kbuild"
@@ -114,6 +114,7 @@ install: sources
 	install -dm755 "$(DESTDIR)$(DKMS_PREFIX)/patches/bt"
 	install -dm755 "$(DESTDIR)$(DKMS_PREFIX)/patches/wifi"
 	install -m644 "$(TOPDIR)mt6639-bt-6.19.patch" "$(DESTDIR)$(DKMS_PREFIX)/patches/bt/"
+	install -m644 "$(TOPDIR)mt6639-bt-01-fix-initialization.patch" "$(DESTDIR)$(DKMS_PREFIX)/patches/bt/"
 	install -m644 "$(TOPDIR)mt7902-wifi-6.19.patch" "$(DESTDIR)$(DKMS_PREFIX)/patches/wifi/"
 	install -m644 $(TOPDIR)mt7927-wifi-*.patch "$(DESTDIR)$(DKMS_PREFIX)/patches/wifi/"
 	@echo "==> Install complete."

--- a/mt6639-bt-01-fix-initialization.patch
+++ b/mt6639-bt-01-fix-initialization.patch
@@ -1,0 +1,23 @@
+--- a/drivers/bluetooth/btmtk.c
++++ b/drivers/bluetooth/btmtk.c
+@@ -1004,7 +1004,7 @@
+ 	if (!btmtk_data->isopkt_intf)
+ 		return -ENODEV;
+ 
+-	err = usb_set_interface(btmtk_data->udev, MTK_ISO_IFNUM, 1);
++	err = usb_set_interface(btmtk_data->udev, MTK_ISO_IFNUM, (btmtk_data->dev_id == 0x6639) ? 0 : 1);
+ 	if (err < 0) {
+ 		bt_dev_err(hdev, "setting interface failed (%d)", -err);
+ 		return err;
+@@ -1325,6 +1325,11 @@
+ 		fw_flavor = (fw_flavor & 0x00000080) >> 7;
+ 	}
+ 
++	if (!dev_id) {
++		bt_dev_info(hdev, "MT6639: raw CHIPID=0x0000, forcing chip=0x6639");
++		dev_id = 0x6639;
++	}
++
+ 	btmtk_data->dev_id = dev_id;
+ 
+ 	err = btmtk_register_coredump(hdev, btmtk_data->drv_name, fw_version);


### PR DESCRIPTION
This PR resolves Bluetooth initialization failures on the MediaTek MT7927 (MT6639) observed on an ASUS X870E ProArt motherboard. 

### Symptoms Resolved:
1. **CHIPID=0x0000**: The chip incorrectly reports a raw CHIPID of 0x0000 via USB, causing the driver to skip the 0x6639 initialization path. This mirrors the existing 'forcing chip=0x7927' workaround already present in the WiFi driver (mt76).
2. **Error 22 (setting interface failed)**: Caused by the driver attempting to use Alternate Setting 1 for the ISO interface (Interface 2), which is not present in the MT7927 descriptor (only Alt 0 is supported).

### Key Fixes:
1. Forces `dev_id = 0x6639` if the raw `CHIPID` read returns `0x0000`.
2. Sets the ISO interface (Interface 2) to Alternate Setting `0` specifically for the `0x6639` variant to match hardware capabilities.

### Changes:
- Added `mt6639-bt-01-fix-initialization.patch` with the initialization workarounds.
- Updated `Makefile` to apply all `mt6639-bt-*.patch` files in a loop (matching the pattern used for WiFi patches) and ensure they are installed in the DKMS source tree.

Tested and verified on Arch, Kern: 6.19.6 with an ASUS X870E ProArt motherboard.