### PR TITLE
Add compat layer for kernels 6.17-6.18 (airoha_offload.h stub)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ $(STAMP):
 	cp "$(TOPDIR)mt76.Kbuild"      "$(SRCDIR)/mt76/Kbuild"
 	cp "$(TOPDIR)mt7921.Kbuild"    "$(SRCDIR)/mt76/mt7921/Kbuild"
 	cp "$(TOPDIR)mt7925.Kbuild"    "$(SRCDIR)/mt76/mt7925/Kbuild"
+	@echo "==> Installing compat headers..."
+	mkdir -p "$(SRCDIR)/mt76/compat/include/linux/soc/airoha"
+	cp "$(TOPDIR)compat-airoha-offload.h" \
+		"$(SRCDIR)/mt76/compat/include/linux/soc/airoha/airoha_offload.h"
 	@echo "==> Sources ready in $(SRCDIR)/"
 	@touch "$(STAMP)"
 
@@ -96,6 +100,10 @@ install: sources
 	install -m644 $(SRCDIR)/mt76/*.c $(SRCDIR)/mt76/*.h \
 		"$(DESTDIR)$(DKMS_PREFIX)/mt76/"
 	install -m644 $(SRCDIR)/mt76/Kbuild "$(DESTDIR)$(DKMS_PREFIX)/mt76/"
+	# Compat headers for kernels < 6.19 (airoha_offload.h stub)
+	install -dm755 "$(DESTDIR)$(DKMS_PREFIX)/mt76/compat/include/linux/soc/airoha"
+	install -m644 $(SRCDIR)/mt76/compat/include/linux/soc/airoha/airoha_offload.h \
+		"$(DESTDIR)$(DKMS_PREFIX)/mt76/compat/include/linux/soc/airoha/"
 	install -m644 $(SRCDIR)/mt76/mt7921/*.c $(SRCDIR)/mt76/mt7921/*.h \
 		"$(DESTDIR)$(DKMS_PREFIX)/mt76/mt7921/"
 	install -m644 $(SRCDIR)/mt76/mt7921/Kbuild "$(DESTDIR)$(DKMS_PREFIX)/mt76/mt7921/"

--- a/compat-airoha-offload.h
+++ b/compat-airoha-offload.h
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Stub for kernels < 6.19 that lack linux/soc/airoha/airoha_offload.h.
+ *
+ * Airoha NPU offload targets ARM SoCs (MT7988) and is never active on x86.
+ * This provides the types and no-op inlines that mt76.h needs to compile.
+ */
+#ifndef AIROHA_OFFLOAD_H
+#define AIROHA_OFFLOAD_H
+
+#include <linux/skbuff.h>
+
+enum {
+	PPE_CPU_REASON_HIT_UNBIND_RATE_REACHED = 0x0f,
+};
+
+struct airoha_ppe_dev {
+	struct {
+		int (*setup_tc_block_cb)(struct airoha_ppe_dev *dev,
+					 void *type_data);
+		void (*check_skb)(struct airoha_ppe_dev *dev,
+				  struct sk_buff *skb, u16 hash,
+				  bool rx_wlan);
+	} ops;
+
+	void *priv;
+};
+
+static inline struct airoha_ppe_dev *airoha_ppe_get_dev(struct device *dev)
+{
+	return NULL;
+}
+
+static inline void airoha_ppe_put_dev(struct airoha_ppe_dev *dev)
+{
+}
+
+static inline int
+airoha_ppe_dev_setup_tc_block_cb(struct airoha_ppe_dev *dev, void *type_data)
+{
+	return -EOPNOTSUPP;
+}
+
+static inline void airoha_ppe_dev_check_skb(struct airoha_ppe_dev *dev,
+					    struct sk_buff *skb, u16 hash,
+					    bool rx_wlan)
+{
+}
+
+/* Enum types referenced by mt76.h inline wrappers */
+enum airoha_npu_wlan_set_cmd { __AIROHA_NPU_WLAN_SET_CMD_MAX };
+enum airoha_npu_wlan_get_cmd { __AIROHA_NPU_WLAN_GET_CMD_MAX };
+
+struct airoha_npu {};
+
+static inline struct airoha_npu *airoha_npu_get(struct device *dev)
+{
+	return NULL;
+}
+
+static inline void airoha_npu_put(struct airoha_npu *npu)
+{
+}
+
+static inline int airoha_npu_wlan_init_reserved_memory(struct airoha_npu *npu)
+{
+	return -EOPNOTSUPP;
+}
+
+static inline int airoha_npu_wlan_send_msg(struct airoha_npu *npu,
+					   int ifindex,
+					   enum airoha_npu_wlan_set_cmd cmd,
+					   void *data, int data_len, gfp_t gfp)
+{
+	return -EOPNOTSUPP;
+}
+
+static inline int airoha_npu_wlan_get_msg(struct airoha_npu *npu, int ifindex,
+					  enum airoha_npu_wlan_get_cmd cmd,
+					  void *data, int data_len, gfp_t gfp)
+{
+	return -EOPNOTSUPP;
+}
+
+static inline u32 airoha_npu_wlan_get_queue_addr(struct airoha_npu *npu,
+						  int qid, bool xmit)
+{
+	return 0;
+}
+
+static inline void airoha_npu_wlan_set_irq_status(struct airoha_npu *npu,
+						   u32 val)
+{
+}
+
+static inline u32 airoha_npu_wlan_get_irq_status(struct airoha_npu *npu,
+						  int q)
+{
+	return 0;
+}
+
+static inline void airoha_npu_wlan_enable_irq(struct airoha_npu *npu, int q)
+{
+}
+
+static inline void airoha_npu_wlan_disable_irq(struct airoha_npu *npu, int q)
+{
+}
+
+#endif /* AIROHA_OFFLOAD_H */

--- a/mt76.Kbuild
+++ b/mt76.Kbuild
@@ -13,5 +13,8 @@ mt76-connac-lib-y := mt76_connac_mcu.o mt76_connac_mac.o mt76_connac3_mac.o
 mt792x-lib-y := mt792x_core.o mt792x_mac.o mt792x_trace.o \
 		mt792x_debugfs.o mt792x_dma.o mt792x_acpi_sar.o
 
+# Use compat stub for airoha_offload.h on kernels < 6.19
+subdir-ccflags-y += $(if $(wildcard $(srctree)/include/linux/soc/airoha/airoha_offload.h),,-I$(src)/compat/include)
+
 CFLAGS_trace.o := -I$(src)
 CFLAGS_mt792x_trace.o := -I$(src)


### PR DESCRIPTION
## Problem

The mt76 WiFi driver (6.19 source) fails to compile on kernels < 6.19 because `linux/soc/airoha/airoha_offload.h` does not exist in those kernel headers. This header was added in 6.19 for Airoha NPU offload support on ARM SoCs.

## Solution

Ship a minimal stub header that provides the struct/enum types and no-op inline functions that `mt76.h` needs. A Kbuild wildcard auto-detects at compile time whether the real header exists:

- **6.19+**: real header found, compat path skipped
- **6.17-6.18**: header missing, stub provides no-op implementations

Airoha NPU offload is ARM SoC-only (MT7988) and never active on x86, so stubs are functionally equivalent.

## Key changes

- Add `compat/include/linux/soc/airoha/airoha_offload.h` with struct definitions and no-op inlines
- Add Kbuild wildcard for compile-time header detection
- Update Makefile to copy and install the compat directory

## Reviewer notes

Alternative to #30's `apply-compat.sh` approach. No runtime scripts, no `sed` injection, no mt76 source modifications. Tested on 6.19.9 (all validation checks pass). Scoped to 6.17+ per discussion in #30.

cc @samutoljamo