### PR TITLE
fix: Address build, security, and correctness issues across project

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -38,9 +38,10 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          gh release create "${{ steps.tag.outputs.tag }}" \
-            --title "${{ steps.tag.outputs.tag }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --notes-file /tmp/release-notes.md
 
   build-rpm:
@@ -59,9 +60,10 @@ jobs:
       - name: Upload RPM to release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.create-release.outputs.tag }}
         run: |
           dnf install -y gh
-          gh release upload "${{ needs.create-release.outputs.tag }}" \
+          gh release upload "$TAG" \
             rpmbuild/RPMS/noarch/*.rpm \
             --repo "${{ github.repository }}"
 
@@ -80,6 +82,7 @@ jobs:
       - name: Upload DEB to release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.create-release.outputs.tag }}
         run: |
-          gh release upload "${{ needs.create-release.outputs.tag }}" \
+          gh release upload "$TAG" \
             *.deb

--- a/build-check.sh
+++ b/build-check.sh
@@ -131,9 +131,9 @@ for i in "${!commits[@]}"; do
 	git -C "$KERNEL_TREE" checkout "$commit" --quiet 2>/dev/null
 
 	# Build
+	build_rc=0
 	build_out=$(make -C "$KDIR" M="$KERNEL_TREE/$module_dir" modules \
-		$_llvm -j"$_nproc" 2>&1) || true
-	build_rc=$?
+		$_llvm -j"$_nproc" 2>&1) || build_rc=$?
 
 	# Check for actual compilation errors (ignore modpost/symbol warnings)
 	has_error=false

--- a/dkms.conf
+++ b/dkms.conf
@@ -7,6 +7,7 @@ _KDIR="${kernel_source_dir}"
 _BUILD="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 
 MAKE[0]="if ! grep -q 'MT6639' ${kernel_source_dir}/drivers/bluetooth/btmtk.h 2>/dev/null; then make ${_LLVM} -C ${_KDIR} M=${_BUILD}/drivers/bluetooth modules; fi && make ${_LLVM} -C ${_KDIR} M=${_BUILD}/mt76 modules"
+CLEAN="make -C ${_KDIR} M=${_BUILD}/drivers/bluetooth clean 2>/dev/null; make -C ${_KDIR} M=${_BUILD}/mt76 clean"
 
 # Bluetooth modules
 BUILT_MODULE_NAME[0]="btusb"

--- a/extract_firmware.py
+++ b/extract_firmware.py
@@ -40,6 +40,12 @@ def extract_by_name(data, name, output_path):
     # Align to 4-byte boundary
     entry_pos = (entry_pos + 3) & ~3
 
+    if entry_pos + 8 > len(data):
+        raise RuntimeError(
+            f"Unexpected end of data while parsing entry '{name}' "
+            f"(need 8 bytes at offset {entry_pos}, but data is {len(data)} bytes)"
+        )
+
     data_offset = struct.unpack_from("<I", data, entry_pos)[0]
     data_size = struct.unpack_from("<I", data, entry_pos + 4)[0]
 
@@ -66,7 +72,7 @@ def extract_all(input_path, output_dir):
     input_path can be a .zip file (reads mtkwlan.dat from it) or a raw
     mtkwlan.dat file.
     """
-    if input_path.endswith(".zip"):
+    if input_path.lower().endswith(".zip"):
         with zipfile.ZipFile(input_path) as zf:
             data = zf.read("mtkwlan.dat")
     else:

--- a/mediatek-mt7927-dkms.spec
+++ b/mediatek-mt7927-dkms.spec
@@ -55,10 +55,12 @@ dkms remove -m %{dkms_name} -v %{version} --rpm_safe_upgrade --all || :
 
 %files
 %{_usrsrc}/%{dkms_name}-%{version}
-%dir /usr/lib/firmware/mediatek/mt7927
+%dir /usr/lib/firmware/mediatek
 %dir /usr/lib/firmware/mediatek/mt7927
 /usr/lib/firmware/mediatek/mt7927/BT_RAM_CODE_MT6639_2_1_hdr.bin
 /usr/lib/firmware/mediatek/mt7927/WIFI_MT6639_PATCH_MCU_2_1_hdr.bin
 /usr/lib/firmware/mediatek/mt7927/WIFI_RAM_CODE_MT6639_2_1.bin
 
 %changelog
+* Sun Mar 29 2026 Eder Sánchez <eder.sanchez@pm.me> - 2.9-1
+- See CHANGELOG.md for detailed release notes

--- a/test-driver.sh
+++ b/test-driver.sh
@@ -188,7 +188,7 @@ dmesg_out="$(dmesg 2>/dev/null || true)"
 }
 
 # ---------------------------------------------------------------------------
-# 7b. ASPM status (MT7927 needs ASPM disabled)
+# 8. ASPM status (MT7927 needs ASPM disabled)
 # ---------------------------------------------------------------------------
 check_aspm() {
 	local dmesg_out=""
@@ -222,7 +222,7 @@ dmesg_out="$(dmesg 2>/dev/null || true)"
 }
 
 # ---------------------------------------------------------------------------
-# 8. Bluetooth USB device presence
+# 9. Bluetooth USB device presence
 # ---------------------------------------------------------------------------
 check_bt_usb() {
 	# Known MT6639 BT USB vendor:product pairs
@@ -246,7 +246,7 @@ check_bt_usb() {
 }
 
 # ---------------------------------------------------------------------------
-# 9. Bluetooth firmware loading from dmesg
+# 10. Bluetooth firmware loading from dmesg
 # ---------------------------------------------------------------------------
 check_bt_firmware() {
 	local dmesg_out=""
@@ -291,7 +291,7 @@ dmesg_out="$(dmesg 2>/dev/null || true)"
 }
 
 # ---------------------------------------------------------------------------
-# 10. Bluetooth rfkill status
+# 11. Bluetooth rfkill status
 # ---------------------------------------------------------------------------
 check_bt_rfkill() {
 	if ! command -v rfkill &>/dev/null; then
@@ -315,7 +315,7 @@ check_bt_rfkill() {
 }
 
 # ---------------------------------------------------------------------------
-# 9. Interface detection (auto via sysfs)
+# 12. Interface detection (auto via sysfs)
 # ---------------------------------------------------------------------------
 detect_interface() {
 	local iface=""
@@ -347,7 +347,7 @@ detect_interface() {
 }
 
 # ---------------------------------------------------------------------------
-# EHT / 320MHz / MLO capability
+# 13. EHT / 320MHz / MLO capability
 # ---------------------------------------------------------------------------
 check_eht_caps() {
 	local iface="$1"
@@ -407,7 +407,7 @@ check_eht_caps() {
 }
 
 # ---------------------------------------------------------------------------
-# 13. Device readiness (nmcli)
+# 14. Device readiness (nmcli)
 # ---------------------------------------------------------------------------
 check_device_ready() {
 	local iface="$1"
@@ -450,7 +450,7 @@ check_device_ready() {
 }
 
 # ---------------------------------------------------------------------------
-# 14. Regulatory / 6GHz NO_IR status
+# 15. Regulatory / 6GHz NO_IR status
 # ---------------------------------------------------------------------------
 check_regulatory() {
 	local iface="$1"
@@ -504,7 +504,7 @@ check_regulatory() {
 }
 
 # ---------------------------------------------------------------------------
-# 15. WiFi scan - report available bands
+# 16. WiFi scan - report available bands
 # ---------------------------------------------------------------------------
 check_scan() {
 	local iface="$1"
@@ -546,7 +546,7 @@ check_scan() {
 }
 
 # ---------------------------------------------------------------------------
-# 11. Connection status
+# 17. Connection status
 # ---------------------------------------------------------------------------
 check_connection() {
 	local iface="$1"
@@ -604,7 +604,7 @@ check_connection() {
 }
 
 # ---------------------------------------------------------------------------
-# 12. Quick data path test (3 pings to gateway)
+# 18. Quick data path test (3 pings to gateway)
 # ---------------------------------------------------------------------------
 check_data_path() {
 	local iface="$1"
@@ -659,7 +659,7 @@ check_data_path() {
 }
 
 # ---------------------------------------------------------------------------
-# 13. Error pattern check in dmesg
+# 19. Error pattern check in dmesg
 # ---------------------------------------------------------------------------
 check_errors() {
 	local dmesg_out=""


### PR DESCRIPTION
Addresses some issues found in the project by a team of 4 specialized agents:

- build-check.sh: Fix critical bug where build_rc was always 0 due to || true, making the script unable to detect build failures. Changed to || build_rc=$? to capture real exit codes.
- dkms.conf: Add missing CLEAN directive for proper out-of-tree build cleanup across both drivers/bluetooth and mt76 directories, preventing stale .o files from causing miscompilation on kernel upgrades.
- mediatek-mt7927-dkms.spec: Fix duplicate %dir /usr/lib/firmware/mediatek/mt7927 — first entry changed to parent %dir /usr/lib/firmware/mediatek. Add initial %changelog entry.
- release-packages.yml: Pass tag values through env: blocks instead of inline ${{ steps.tag.outputs.tag }} in shell run: blocks, preventing potential shell injection via crafted tag names.
- extract_firmware.py: Add bounds checking before struct.unpack_from calls to prevent unhelpful errors on truncated firmware data. Make .zip detection case-insensitive.
- test-driver.sh: Renumber all section headers sequentially (1-19), fixing duplicates (two "9"s, two "13"s) and out-of-order numbering.
