### PR TITLE
Hardware Support Confirmation: Gigabyte X870E AERO X3D DARK WOOD - Readme.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ device ID and firmware patches not yet in mainline. Supports kernels 6.17+.
 | Gigabyte X870E Aorus Master X3D | 0489:e10f | 14c3:7927 |
 | Gigabyte Z790 AORUS MASTER X | 0489:e10f | 14c3:7927 |
 | Gigabyte Z790 AORUS ELITE X WiFi7 | 0489:e10f | 14c3:7927 |
+| Gigabyte X870E Aero Wood/Dark Wood X3D | 0489:e10f | 14c3:7927 |
 | MSI MEG X870E ACE MAX | 0489:e110 | 14c3:7927 |
 | Lenovo Legion Pro 7 16ARX9 | 0489:e0fa | 14c3:7927 |
 | Lenovo Legion Pro 7 16AFR10H | 0489:e0fa | 14c3:7927 |


### PR DESCRIPTION
Small change added 2 new motherboard names to the list on with their Wi-Fi and Bluetooth ids , the driver works fine needs secure boot off, installation on fedora was simple just downloaded and installed the file, the post install steps felt useless even returned error, the  Bluetooth driver itself went missing completely - followed last steps mentioned regarding the full power off and drain - Bluetooth drivers started working. I am running a dual-boot setup (Fedora 43 / Windows) with separate SSD which has windows so after installation had a network driver corruption in windows causing a BSOD. I am not sure if it was network driver exactly or not but I am attaching the who crashed analysis of the bug check. 

Thanks for the amazing work on this DKMS package!

---

Findings :

* PC Specs
<img width="752" height="287" alt="image" src="https://github.com/user-attachments/assets/7047764d-c3a5-4726-952b-781f6d5aa0c0" />

* Motherboard specs:
<img width="1027" height="198" alt="Screenshot 2026-05-05 093531" src="https://github.com/user-attachments/assets/9137d4b0-4499-4286-af3b-4db935a5ae49" />

* Windows Reliability monitor:

<img width="869" height="529" alt="image" src="https://github.com/user-attachments/assets/5a6c9c23-ef15-4558-b017-5dfd0b84cce4" />

* Who Crashed Analysis:

<img width="1913" height="911" alt="Screenshot 2026-05-05 072449" src="https://github.com/user-attachments/assets/0900a0e5-2ada-43dc-a945-aad64783620c" />

