### PR TITLE
fix(dkms): support Linux 7.1 action frame API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,12 @@ $(STAMP): check-version
 	@echo "==> Applying MT7927 WiFi patches..."
 	@for p in $(TOPDIR)mt7927-wifi-*.patch; do \
 		echo "  $$(basename "$$p")"; \
-		patch -d "$(SRCDIR)/mt76" -p1 < "$$p"; \
+		patch -d "$(SRCDIR)/mt76" -p1 < "$$p" || exit 1; \
 	done
 	@echo "==> Applying MT6639 Bluetooth patches..."
 	@for p in $(TOPDIR)mt6639-bt-[0-9]*.patch $(TOPDIR)mt6639-bt-compat-*.patch; do \
 		echo "  $$(basename "$$p")"; \
-		patch -d "$(SRCDIR)/bluetooth" -p1 < "$$p"; \
+		patch -d "$(SRCDIR)/bluetooth" -p1 < "$$p" || exit 1; \
 	done
 	cp "$(TOPDIR)bluetooth.Makefile" "$(SRCDIR)/bluetooth/Makefile"
 	@echo "==> Installing Kbuild files..."

--- a/mt7927-wifi-20-compat-linux-7-1-ieee80211-action-api.patch
+++ b/mt7927-wifi-20-compat-linux-7-1-ieee80211-action-api.patch
@@ -1,0 +1,53 @@
+wifi: mt76: add Linux 7.1 action frame API compatibility
+
+Linux 7.1 changed struct ieee80211_mgmt action frame accessors and made
+IEEE80211_MIN_ACTION_SIZE take the fixed-field member name. Keep the DKMS
+source building on older kernels while using the new API on 7.1 and newer.
+
+Signed-off-by: Komzpa <me@komzpa.net>
+
+diff --git a/mt76_connac_mac.c b/mt76_connac_mac.c
+index a417a0a..734d9f0 100644
+--- a/mt76_connac_mac.c
++++ b/mt76_connac_mac.c
+@@ -4,2 +4,3 @@
+ #include "dma.h"
++#include <linux/version.h>
+ 
+@@ -412,8 +413,15 @@ mt76_connac2_mac_write_txwi_80211(struct mt76_dev *dev, __le32 *txwi,
+ 
+ 	if (ieee80211_is_action(fc) &&
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++	    skb->len >= IEEE80211_MIN_ACTION_SIZE(action_code) + 1 + 2 &&
++	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
++	    mgmt->u.action.action_code == WLAN_ACTION_ADDBA_REQ) {
++		u16 capab = le16_to_cpu(mgmt->u.action.addba_req.capab);
++#else
+ 	    skb->len >= IEEE80211_MIN_ACTION_SIZE + 1 + 1 + 2 &&
+ 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
+ 	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ) {
+ 		u16 capab = le16_to_cpu(mgmt->u.action.u.addba_req.capab);
++#endif
+ 
+ 		txwi[5] |= cpu_to_le32(MT_TXD5_ADD_BA);
+diff --git a/mt7925/mac.c b/mt7925/mac.c
+index eb09e74..c841b3b 100644
+--- a/mt7925/mac.c
++++ b/mt7925/mac.c
+@@ -4,2 +4,3 @@
+ #include <linux/timekeeping.h>
++#include <linux/version.h>
+ #include "mt7925.h"
+@@ -672,6 +673,12 @@ mt7925_mac_write_txwi_80211(struct mt76_dev *dev, __le32 *txwi,
+ 
+ 	if (ieee80211_is_action(fc) &&
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++	    skb->len >= IEEE80211_MIN_ACTION_SIZE(action_code) + 1 &&
++	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
++	    mgmt->u.action.action_code == WLAN_ACTION_ADDBA_REQ)
++#else
+ 	    skb->len >= IEEE80211_MIN_ACTION_SIZE + 1 &&
+ 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
+ 	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ)
++#endif
+ 		tid = MT_TX_ADDBA;


### PR DESCRIPTION
## Summary
- add a DKMS WiFi compatibility patch for the Linux 7.1 `ieee80211_mgmt` action-frame API changes
- use the new `IEEE80211_MIN_ACTION_SIZE(action_code)` and `mgmt->u.action.action_code` / `mgmt->u.action.addba_req` accessors on Linux 7.1+
- preserve the existing code path for older supported kernels
- make the Makefile patch loops fail immediately when a patch fails, instead of continuing after a malformed patch

## Validation
- `make -C /usr/local/src/mediatek-mt7927-dkms sources`
- `make -C /lib/modules/7.1-amd64/build M=/usr/local/src/mediatek-mt7927-dkms/_build/bluetooth modules`
- `make -C /lib/modules/7.1-amd64/build M=/usr/local/src/mediatek-mt7927-dkms/_build/mt76 modules`
- `make -C /lib/modules/7.0.3+deb14-amd64/build M=/usr/local/src/mediatek-mt7927-dkms/_build/bluetooth modules`
- `make -C /lib/modules/7.0.3+deb14-amd64/build M=/usr/local/src/mediatek-mt7927-dkms/_build/mt76 modules`
