### PR TITLE
wifi: mt76: mt7925: track valid BSS txpower

### DIFF
--- a/mt7927-wifi-20-fix-txpower-reporting-before-bss-txpower.patch
+++ b/mt7927-wifi-20-fix-txpower-reporting-before-bss-txpower.patch
@@ -1,0 +1,57 @@
+wifi: mt76: mt7925: track valid BSS TX power before reporting
+
+mt7925 stores per-BSS TX power once mac80211 sends
+BSS_CHANGED_TXPOWER. Before that event, dev->phy.txpower is still the
+zero-initialized value, but mt7925_mcu_set_rate_txpower() treats it as a
+valid configured power and feeds 0 into mt76_get_power_bound(). This
+leaves phy->txpower_cur at 0 and makes userspace report txpower 0.00 dBm
+after reload or while disconnected.
+
+Track whether the per-BSS TX power has actually been received. Until it
+has, fall back first to hw->conf.power_level and then to the current
+channel regulatory max power before entering the existing mt76 power
+bound and rate power limit path. Once mac80211 has sent BSS TX power,
+use it as-is, including a legitimate 0 dBm value.
+
+Signed-off-by: Darafei Praliaskouski <me@komzpa.net>
+
+--- a/mt7925/main.c
++++ b/mt7925/main.c
+@@ -1993,8 +1993,9 @@ static void mt7925_link_info_changed(str
+ 		mt7925_mcu_set_rssimonitor(dev, vif);
+ 
+ 	if (changed & BSS_CHANGED_TXPOWER &&
+-	    info->txpower != phy->txpower) {
++	    (!phy->txpower_set || info->txpower != phy->txpower)) {
+ 		phy->txpower = info->txpower;
++		phy->txpower_set = true;
+ 		mt7925_mcu_set_rate_txpower(phy->mt76);
+ 	}
+ 
+--- a/mt7925/mcu.c
++++ b/mt7925/mcu.c
+@@ -3915,8 +3915,12 @@ int mt7925_mcu_set_rate_txpower(struct m
+ 		struct mt76_power_limits la = {};
+ 		int tx_power;
+ 
+-		tx_power = mt76_get_power_bound(phy,
+-						dev->phy.txpower);
++		tx_power = dev->phy.txpower_set ? dev->phy.txpower :
++						  mdev->hw->conf.power_level;
++		if (!tx_power)
++			tx_power = phy->chandef.chan->max_power;
++
++		tx_power = mt76_get_power_bound(phy, tx_power);
+ 		tx_power = mt76_get_rate_power_limits(phy,
+ 						      phy->chandef.chan,
+ 						      &la, tx_power);
+--- a/mt792x.h
++++ b/mt792x.h
+@@ -168,6 +168,7 @@ struct mt792x_phy {
+ 	u8 slottime;
+ 
+ 	int txpower;
++	bool txpower_set;
+ 
+ 	u32 rx_ampdu_ts;
+ 	u32 ampdu_ref;


### PR DESCRIPTION
## Summary

Add one follow-up Wi-Fi patch for mt7925 TX power reporting before mac80211 has delivered `BSS_CHANGED_TXPOWER`.

Current patch 18 stores per-BSS TX power in `dev->phy.txpower`, but there is no validity state for that field. Before the first `BSS_CHANGED_TXPOWER` event, `dev->phy.txpower` is just the zero-initialized value. `mt7925_mcu_set_rate_txpower()` treats that zero as configured power, feeds it into `mt76_get_power_bound()`, and userspace reports `txpower 0.00 dBm` after reload/disconnected state.

This patch tracks whether BSS TX power has actually been received:

1. add `txpower_set` next to `txpower`;
2. set it when handling `BSS_CHANGED_TXPOWER`;
3. use `dev->phy.txpower` only when `txpower_set` is true, so a legitimate configured `0 dBm` remains valid;
4. before BSS TX power is known, fall back to `hw->conf.power_level`, then current channel regulatory max power;
5. continue through `mt76_get_power_bound()` and `mt76_get_rate_power_limits()`.

## Verification

- `patch --dry-run --fuzz=0` passes against the generated mt76 tree after patches 1-19.
- `make sources` passes on this branch.
- Generated source contains the expected `txpower_set` guard and channel max fallback.
- Live nucat evidence from the fuller test branch: after DKMS install and module reload without reboot, `iw dev wlp8s0 info` changed from `txpower 0.00 dBm` to `txpower 23.00 dBm`.

## Scope and routing

This PR is intentionally minimized to the DKMS/backport txpower reporting fix only. It does not claim to fix Bluetooth/Wi-Fi coexistence and does not include the separate Linux 7.1 `ieee80211_mgmt.u.action` build-compat patch.

This is not a Linux wireless upstream submission as-is: current `wireless-next` does not have this repo's patch-18 `dev->phy.txpower` path, so a real upstream submission would need a separate mt76 patch/series against `wireless` or `wireless-next` and should be sent via `git send-email` to linux-wireless rather than as this GitHub patch-file PR.
